### PR TITLE
Some maybe questionable CAN fixes

### DIFF
--- a/log_exporter.py
+++ b/log_exporter.py
@@ -28,6 +28,30 @@ def log_success(phrase):
 def log(phrase):
     print(phrase)
 
+# Helper functions --------------------------------------------------------------------#
+def load_can_dbcs(dbc_fpath: str, recursive: bool = False) -> cantools.db.Database:
+    """
+    Scans a folder (and optionally all subfolders) for DBC files and loads them into a
+    single CAN database.
+    :param dbc_fpath: The path to the CAN DBC folder
+    :param recursive: Whether to search subdirectories recursively (default: False)
+    :return: The loaded CAN database
+    """
+    db = cantools.db.Database()
+    if not dbc_fpath or not os.path.isdir(dbc_fpath):
+        return db
+    if recursive:
+        for root, _, files in os.walk(dbc_fpath):
+            for file in files:
+                if file.endswith(".dbc"):
+                    db.add_dbc_file(os.path.join(root, file))
+    else:
+        for file in os.listdir(dbc_fpath):
+            if file.endswith(".dbc"):
+                db.add_dbc_file(os.path.join(dbc_fpath, file))
+    return db
+#--------------------------------------------------------------------------------------#
+
 class LogExporter():
     """
     Exports a binary log files into csv files
@@ -41,7 +65,7 @@ class LogExporter():
     MAX_JUMP_MS = 300 # Creates new file if message is this far from previous
 
     def __init__(self, dbc_path):
-        self.db = cantools.db.load_file(dbc_path)
+        self.db = load_can_dbcs(dbc_path)
         self._init_col_dict()
 
         self.start_t = 0
@@ -257,8 +281,9 @@ out_dir = "D:/Otterbein_04_06_2024/Evening_parsed"
 out_dir = "/Users/adityaanand/PER/logs_2025/LOGS 412 Parsed"
 
 #dbc_dir = "D:/Downloads/per_dbc.dbc"
-dbc_dir = "/Users/adityaanand/dev/per/firmware/common/daq/per_dbc_VCAN.dbc"
+# dbc_dir = "/Users/adityaanand/dev/per/firmware/common/daq/per_dbc_VCAN.dbc"
+dbc_fpath = os.path.join("/Users/adityaanand/dev/per/firmware/common/daq/")
 
-le = LogExporter(dbc_dir)
+le = LogExporter(dbc_fpath)
 
 le.parse_files(p, out_dir, fill_empty_vals=True)

--- a/main.py
+++ b/main.py
@@ -54,7 +54,7 @@ class Main(QtWidgets.QMainWindow):
         # Load Configurations (dictionaries)
         firmware_base = config['firmware_path']
         self.daq_config = utils.load_json_config(os.path.join(firmware_base, 'common/daq/daq_config.json'), os.path.join(firmware_base, 'common/daq/daq_schema.json'))
-        self.can_config = utils.load_json_config(os.path.join(firmware_base, 'common/daq/can_config.json'), os.path.join(firmware_base, 'common/daq/can_schema.json'))
+        self.can_config = utils.load_json_nodes(os.path.join(firmware_base, 'common/daq/node_configs'))
         self.fault_config = utils.load_json_config(os.path.join(firmware_base, 'common/faults/fault_config.json'), os.path.join(firmware_base, 'common/faults/fault_schema.json'))
         self.fault_config = DaqProtocol.create_ids(self, self.fault_config)
 

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ class Main(QtWidgets.QMainWindow):
 
         # Can Bus Initialization
         # Default to the VCAN DBC, but this will be configurable.
-        self.can_bus = CanBus(os.path.join(firmware_base, 'common/daq/per_dbc_VCAN.dbc'), config['default_ip'], self.can_config, firmware_base)
+        self.can_bus = CanBus(os.path.join(firmware_base, 'common/daq/'), config['default_ip'], self.can_config, firmware_base)
         self.can_bus.connect_sig.connect(self.updateConnectionStatus)
         self.can_bus.write_sig.connect(self.updateWriteConnectionStatus)
         self.can_bus.bus_load_sig.connect(self.updateBusLoad)

--- a/utils.py
+++ b/utils.py
@@ -3,6 +3,7 @@ from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 import numpy as np
 import sys
+import os
 
 # Global Variables
 def initGlobals():
@@ -78,6 +79,28 @@ def load_json_config(config_path, schema_path):
         sys.exit(1)
 
     return config
+
+def load_json_nodes(nodes_fpath):
+    """ loads each node config from a folder and combines it into one dict """
+    can_config = {}
+    for file in os.listdir(nodes_fpath):
+        if file.endswith(".json"):
+            node_config = json.load(open(os.path.join(nodes_fpath, file)))
+            node_busses = node_config['busses']
+
+            existing_busses = can_config.get('busses', [])
+            for bus in node_busses:
+                found = False
+                for existing_bus in existing_busses:
+                    if bus['bus_name'] == existing_bus['bus_name']:
+                        found = True
+                        existing_bus['nodes'].extend(bus['nodes'])
+                        break
+                if not found:
+                    existing_busses.append(bus)
+            can_config['busses'] = existing_busses
+    return can_config
+
 
 def clearDictItems(dictionary:dict):
     """ recursively calls clear on items in multidimensional dict"""


### PR DESCRIPTION
* Multi DBC usage at once may be overkill but I don't think it hurts to have it? (Not the prettiest implementation but I think it could work and it won't matter once DaqApp2 is in running condition)
* Supports joining the node configs into one dict for the rest of the app (because `can_config.json` was split up)